### PR TITLE
Mask rename to avoid `UIView` name collision

### DIFF
--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/UITextFieldMask.h
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/UITextFieldMask.h
@@ -61,7 +61,7 @@
 
 /** The mask to be applied to the text field.
  */
-@property (nonatomic, strong) NSStringMask *mask;
+@property (nonatomic, strong) NSStringMask *textMask;
 
 #pragma mark - Instance Methods
 /// @name Instance Methods

--- a/JVFloatLabeledTextField/JVFloatLabeledTextField/UITextFieldMask.m
+++ b/JVFloatLabeledTextField/JVFloatLabeledTextField/UITextFieldMask.m
@@ -25,7 +25,7 @@
     self = [super init];
     if (self)
     {
-        self.mask = mask;
+        self.textMask = mask;
     }
     return self;
 }
@@ -40,7 +40,7 @@
 
 - (void)setMask:(NSStringMask *)mask
 {
-    _mask = mask;
+    _textMask = mask;
     
     [super setDelegate:(mask ? self : nil)];
 }
@@ -55,15 +55,15 @@
         return NO;
     }
     
-    if (!self.mask) {
+    if (!self.textMask) {
         return YES;
     }
     
     NSString *mutableString = [textField.text stringByReplacingCharactersInRange:range withString:string];
     
-    NSString *clean = [self.mask validCharactersForString:mutableString];
+    NSString *clean = [self.textMask validCharactersForString:mutableString];
     
-    mutableString = [self.mask format:mutableString];
+    mutableString = [self.textMask format:mutableString];
     
     NSRange newRange = NSMakeRange(0, 0);
     
@@ -150,7 +150,7 @@
 {
     [super awakeFromNib];
     
-    if (self.mask)
+    if (self.textMask)
     {
         [super setDelegate:self];
     }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ JVFloatLabeledTextField + NSStringMask
 
 This fork adds [NSStringMask](https://github.com/fjcaetano/NSStringMask), so JVFloatLabeledTextField now inherits from UITextFieldMask.
 
+This fork adds [NSStringMask](https://github.com/fjcaetano/NSStringMask), so JVFloatLabeledTextField now inherits from UITextFieldMask.
+
 Due to space constraints on mobile devices, it is common to rely solely on placeholders as a means to label fields.
 This presents a UX problem, in that, once the user begins to fill out a form, no labels are present.
 


### PR DESCRIPTION
renaming mask property to avoid `UIView` [mask](https://developer.apple.com/reference/uikit/uiview/1622557-mask) name collision